### PR TITLE
Add an Erase action to Undead

### DIFF
--- a/GameView.m
+++ b/GameView.m
@@ -291,8 +291,8 @@ static void saveGameWrite(void *ctx, void *buf, int len)
             extra_labels = TowersLabels;
             extra_button_count = 1;
         } else if (ourgame == &undead) {
-            static const char *UndeadLabels[] = {"Ghost", "Vampire", "Zombie"};
-            main_button_count = 3;
+            static const char *UndeadLabels[] = {"Ghost", "Vampire", "Zombie", "Erase"};
+            main_button_count = 4;
             labels = UndeadLabels;
         } else if (ourgame == &unequal) {
             static const char *UnequalLabels[] = {"Marks", "Hints"};


### PR DESCRIPTION
When playing Undead, it's nice to be able to remove a mark you made, but not the one you just made (which can be removed with undo).  In the desktop version, you do this by typing space.

I've tested this in the iOS simulator, but I don't have an iOS developer account, so I couldn't test it on actual hardware.
