### PR TITLE
Use safe area in game view

### DIFF
--- a/GameView.m
+++ b/GameView.m
@@ -210,10 +210,20 @@ static void saveGameWrite(void *ctx, void *buf, int len)
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone && UIInterfaceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
         toolbar_height = 32;
     }
-    int top_margin = IOS7() ? (20+44) : 0;
+    int top_margin;
+    int bottom_margin;
+    if (@available(iOS 11, *)) {
+        UIEdgeInsets safeAreaInsets = self.safeAreaInsets;
+        top_margin = safeAreaInsets.top;
+        bottom_margin = safeAreaInsets.bottom;
+    } else {
+        top_margin = 20+44;
+        bottom_margin = 0;
+    }
     int usable_height = self.frame.size.height;
     usable_height -= top_margin;
     usable_height -= toolbar_height;
+    usable_height -= bottom_margin;
     CGRect r = CGRectMake(0, top_margin+usable_height, self.frame.size.width, toolbar_height);
     if (toolbar) {
         [toolbar setFrame:r];


### PR DESCRIPTION
In version 1.3.1, the toolbar appears under the home bar for devices without a home button, making them difficult to press (this regression was caused by the SDK update). This PR updates the game view to account for the "safe area".

On my iPhone XS (iOS 14.0), before:

<a href="https://user-images.githubusercontent.com/10134823/93727380-ea1b4080-fb88-11ea-97d6-09df017734d3.PNG"><img src="https://user-images.githubusercontent.com/10134823/93727380-ea1b4080-fb88-11ea-97d6-09df017734d3.PNG" width="384"></a>

After:

<a href="https://user-images.githubusercontent.com/10134823/93727389-f1424e80-fb88-11ea-81c8-ba34936cd7b3.PNG"><img src="https://user-images.githubusercontent.com/10134823/93727389-f1424e80-fb88-11ea-81c8-ba34936cd7b3.PNG" width="384"></a>

On the "iPad Pro (12.9-inch) (3rd generation)" simulator (iOS 13.3), before:

<a href="https://user-images.githubusercontent.com/10134823/93727701-52b6ed00-fb8a-11ea-9672-20e567583d57.png"><img src="https://user-images.githubusercontent.com/10134823/93727701-52b6ed00-fb8a-11ea-9672-20e567583d57.png" width="640"></a>
<a href="https://user-images.githubusercontent.com/10134823/93727677-3450f180-fb8a-11ea-8f70-450db43fa212.png"><img src="https://user-images.githubusercontent.com/10134823/93727677-3450f180-fb8a-11ea-8f70-450db43fa212.png" width="640"></a>

After:

<a href="https://user-images.githubusercontent.com/10134823/93727532-89403800-fb89-11ea-9c10-08bea267e2e4.png"><img src="https://user-images.githubusercontent.com/10134823/93727532-89403800-fb89-11ea-9c10-08bea267e2e4.png" width="640"></a>
<a href="https://user-images.githubusercontent.com/10134823/93727656-14b9c900-fb8a-11ea-879e-9589cf107a95.png"><img src="https://user-images.githubusercontent.com/10134823/93727656-14b9c900-fb8a-11ea-879e-9589cf107a95.png" width="640"></a>